### PR TITLE
カメラ画像処理機能 既存変換

### DIFF
--- a/colorpicker.html
+++ b/colorpicker.html
@@ -45,6 +45,7 @@
     <input type="file" id="fileSelect" accept="image/jpeg,image/png,image/gif" onchange="readImg()"><BR>
     <input type="button" disabled id="analysisImg" value="解析" onclick="analysisImg()"><BR>
     <input type="button" disabled id="x1Img" value="等倍" onclick="openImageWindow()"><BR>
+    <input type="button" id="cameraImg" value="カメラ開始" onclick="operateCamera()"><BR>
 
     <!-- 元画表示 -->
     <Div>

--- a/constant.js
+++ b/constant.js
@@ -7,6 +7,8 @@ const HISTGRAM_COLOR = [
     "rgb(0, 255, 255)", "rgb(255, 0, 255)", "rgb(128, 128, 128)",  //HSV
     "rgb(128, 128, 128)", "rgb(0, 0, 255)", "rgb(255, 0, 0)"];  //YUV
 const SELECT_RANGE_STATE = { NONE: 0, SELECTING: 1, SELECTED: 2 };
+const CAMERA_START = "カメラ開始";
+const CAMERA_STOP = "カメラ停止";
 
 let selectRangeState = SELECT_RANGE_STATE.NONE;
 let firstPosX = 0;
@@ -24,3 +26,10 @@ let compArr = new Array(toneArrR, toneArrG, toneArrB);
 let imageData;
 let imageBase64;
 let selectFileName;
+
+let video;
+let cvsCamera;
+let cvsCtx;
+let callbackId;
+let isCameraImageDraw = false;
+

--- a/controller.js
+++ b/controller.js
@@ -1,7 +1,29 @@
 function analysisImg() {
-    if (fileSelect.files.length == 0) {
-        return;
+    if (isOperateCamera()) {
+        if (fileSelect.files.length == 0 && !isCameraImageDraw) {
+            return;
+        }
     }
+    else {
+        video.pause();
+        imageData = cvsCtx.getImageData(0, 0, IMAGE_WIDHT, IMAGE_HEIGHT);
+        video.srcObject.getTracks().forEach(track => track.stop());
+        imageBase64 = cvsCamera.toDataURL("image/jpeg");
+
+        cancelAnimationFrame(callbackId);
+
+        isCameraImageDraw = true;
+
+        document.getElementById("fileSelect").disabled = false;
+        document.getElementById("colorFormat").disabled = false;
+        document.getElementById("binNumberId").disabled = false;
+        document.getElementById("colorPix").disabled = false;
+        document.getElementById("analysisImg").disabled = false;
+        document.getElementById("x1Img").disabled = false;
+        document.getElementById("selectRect").disabled = false;
+        document.getElementById('cameraImg').value = "カメラ開始";
+    }
+
     let colorFormat = document.getElementById('colorFormat');
 
     switch (colorFormat.value) {

--- a/viewer.js
+++ b/viewer.js
@@ -20,6 +20,8 @@ function clearSelectRange() {
 }
 
 function readImg() {
+    isCameraImageDraw = false;
+    allClear();
 
     const reader = new FileReader();
     const fileSelect = document.getElementById("fileSelect");
@@ -51,6 +53,10 @@ function readImg() {
 }
 
 function clickBaseImg(event) {
+    if (!isOperateCamera()) {
+        return;
+    }
+
     if (isOperationTypeColorPix()) {
         const cvs = document.getElementById("baseImg");
         let ctx = cvs.getContext("2d");
@@ -203,4 +209,91 @@ function openImageWindow() {
         }
     }
     img.src = imageBase64;
+}
+
+function operateCamera() {
+    if (isOperateCamera()) {
+        openCameraImage();
+    }
+    else {
+        stopCameraImage();
+    }
+}
+
+function openCameraImage() {
+    let media;
+
+    allClear();
+
+    video = document.createElement('video');
+    video.id = 'video';
+    video.width = IMAGE_WIDHT;
+    video.height = IMAGE_HEIGHT;
+    video.autoplay = true;
+
+    media = navigator.mediaDevices.getUserMedia({
+        audio: false,
+        video: true
+    }).then(function (stream) {
+        video.srcObject = stream;
+        document.getElementById('cameraImg').value = CAMERA_STOP;
+        document.getElementById("fileSelect").disabled = true;
+        document.getElementById("colorFormat").disabled = false;
+        document.getElementById("colorPix").disabled = true;
+        document.getElementById("binNumberId").disabled = false;
+        document.getElementById("analysisImg").disabled = false;
+        document.getElementById("x1Img").disabled = true;
+        document.getElementById("selectRect").disabled = true;
+    }).catch(function (error) {
+        alert("カメラの接続を確認して下さい。");
+    });
+
+    cvsCamera = document.getElementById("baseImg");
+    cvsCtx = cvsCamera.getContext('2d');
+
+    _canvasUpdate();
+
+    function _canvasUpdate() {
+        cvsCtx.drawImage(video, 0, 0, cvsCamera.width, cvsCamera.height);
+        callbackId = requestAnimationFrame(_canvasUpdate);
+    };
+}
+
+function stopCameraImage() {
+    video.srcObject.getTracks().forEach(track => track.stop());
+    cancelAnimationFrame(callbackId);
+    cvsCtx.clearRect(0, 0, cvsCamera.width, cvsCamera.height);
+    imageBase64 = "";
+
+    document.getElementById('cameraImg').value = CAMERA_START;
+    document.getElementById("fileSelect").disabled = false;
+    document.getElementById("colorFormat").disabled = true;
+    document.getElementById("binNumberId").disabled = true;
+    document.getElementById("analysisImg").disabled = true;
+}
+
+function isOperateCamera() {
+    if (document.getElementById('cameraImg').value == CAMERA_START) {
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+
+function allClear(){
+    // disabledUI(true);
+
+    clearSelectRect();
+    clearPixelColor();
+    clearSelectRange();
+
+    let arrImgName = ["baseImg",
+                    "colorComponent1Img", "colorComponent2Img", "colorComponent3Img",
+                    "histgram1Img", "histgram2Img", "histgram3Img"];
+    for(i=0; i<arrImgName.length; i++){
+        let cvs = document.getElementById(arrImgName[i]);
+        let ctx = cvs.getContext("2d");
+        ctx.clearRect(0, 0, cvs.clientWidth, cvs.clientHeight);
+    }
 }


### PR DESCRIPTION
３．カメラ画像処理機能 既存変換
　　ボタンのカメラ表示ボタンを追加。カメラが無ければボタンイネイブル
　　Webカメラから静止画としてデータを取り出して、既存の変換を掛ける
　　※自身のPCでしか動作確認をおこなっていないため、カメラ認識で不具合が発生するかもしれません
　　※カメラの有無を確認する方法の調査
　　　カメラ表示ボタンはカメラが存在するならツール起動時からEnable、存在しないならDisable
　　　⇒調査したがわからなかったので、以下の対処だけおこなった
　　　　カメラ有りの状態でカメラ起動を拒否された時の処理を実装して逃げる
　　※デュアルモニターで実行した場合、ツールがノートPC本体のモニターで起動した場合と、
　　　モニター側で起動した場合で動作が異なる
　　　ノートPC本体のモニターで起動した場合：カメラが認識される
　　　モニター側で起動した場合：カメラ使用許可のダイアログがおかしな動作になる
